### PR TITLE
Two small changes - TLS and "About" URL

### DIFF
--- a/InfluxDB.indigoPlugin/Contents/Info.plist
+++ b/InfluxDB.indigoPlugin/Contents/Info.plist
@@ -18,7 +18,7 @@
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>http://forums.indigodomo.com/viewtopic.php?f=134&t=18676</string>
+			<string>http://forums.indigodomo.com/viewtopic.php?f=134&amp;t=18676</string>
 		</dict>
 	</array>
 </dict>

--- a/InfluxDB.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/InfluxDB.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -36,6 +36,11 @@
            tooltip="database name in influx">
         <Label>Database:</Label>
     </Field>
+    <Field id="tls"
+           type="checkbox">
+        <Label>Use TLS</Label>
+        <Description>Connect to InfluxDB with TLS (SSL)</Description>
+    </Field>
     <Field id="debug"
            type="checkbox">
         <Label>Debug to Log</Label>

--- a/InfluxDB.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/InfluxDB.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -39,7 +39,9 @@ class Plugin(indigo.PluginBase):
             port=int(self.port),
             username=self.user,
             password=self.password,
-            database=self.database)
+            database=self.database,
+            ssl=self.tls,
+            verify_ssl=True)
 
         if self.pluginPrefs.get('reset', False):
             try:
@@ -111,6 +113,7 @@ class Plugin(indigo.PluginBase):
             self.user = self.pluginPrefs.get('user', 'indigo')
             self.password = self.pluginPrefs.get('password', 'indigo')
             self.database = self.pluginPrefs.get('database', 'indigo')
+            self.tls = self.pluginPrefs.get(u'tls', False)
 
             self.connect()
         except:


### PR DESCRIPTION
The substantive change here is to support InfluxDB over TLS, since I'm running InfluxDB on a different machine entirely than where I'm running Indigo - a cloud VM, so security is necessary.

While I was at it, I noticed that the "About" box for the plugin didn't work - it dropped the thread number. Seems like the URL wasn't properly quoted in the plist.